### PR TITLE
Null safety.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
-## 0.1.0
+# Changelog
 
-- Initial version.
+## 1.0.0
+
+- Null safety.
 
 ## 0.1.1
 
 - Added using function.
+
+## 0.1.0
+
+- Initial version.

--- a/lib/disposables.dart
+++ b/lib/disposables.dart
@@ -1,12 +1,16 @@
 /// A small library to handle classes needing to release it's resources.
 library disposables;
 
-import 'package:quiver/check.dart';
 import 'package:quiver/collection.dart';
 
-part 'src/disposable/disposable.dart';
-part 'src/disposable/disposable_exception.dart';
-part 'src/disposable/disposable_mixin.dart';
-part 'src/disposable/_boolean_disposable.dart';
-part 'src/collection/disposable_collection.dart';
 part 'src/collection/_disposable_list.dart';
+
+part 'src/collection/disposable_collection.dart';
+
+part 'src/disposable/_boolean_disposable.dart';
+
+part 'src/disposable/disposable.dart';
+
+part 'src/disposable/disposable_exception.dart';
+
+part 'src/disposable/disposable_mixin.dart';

--- a/lib/src/collection/_disposable_list.dart
+++ b/lib/src/collection/_disposable_list.dart
@@ -1,7 +1,6 @@
 part of 'package:disposables/disposables.dart';
 
-class _DisposableList<D extends Disposable> extends DelegatingList<D>
-    implements DisposableCollection<D> {
+class _DisposableList<D extends Disposable> extends DelegatingList<D> implements DisposableCollection<D> {
   @override
   final List<D> delegate;
   final bool autoClear;

--- a/lib/src/collection/disposable_collection.dart
+++ b/lib/src/collection/disposable_collection.dart
@@ -1,16 +1,15 @@
 part of 'package:disposables/disposables.dart';
 
 /// Represents a collection
-abstract class DisposableCollection<D extends Disposable>
-    implements Disposable, List<D> {
+abstract class DisposableCollection<D extends Disposable> implements Disposable, List<D> {
   /// Creates a new [DisposableCollection].
-  factory DisposableCollection({bool autoClear}) {
+  factory DisposableCollection({bool? autoClear}) {
     return DisposableCollection.from([], autoClear: autoClear);
   }
 
   /// Creates a [DisposableCollection] from list for [Disposable] instances.
-  factory DisposableCollection.from(Iterable<D> other, {bool autoClear}) {
-    checkNotNull(other, message: () => "other can't be null");
+  factory DisposableCollection.from(Iterable<D> other, {bool? autoClear}) {
+    ArgumentError.checkNotNull(other, "other can't be null");
     return _DisposableList(other.toList(), autoClear ?? false);
   }
 }

--- a/lib/src/disposable/_boolean_disposable.dart
+++ b/lib/src/disposable/_boolean_disposable.dart
@@ -3,9 +3,7 @@ part of 'package:disposables/disposables.dart';
 /// The callback to use when disposing the [Disposable].
 typedef void DisposeFunc();
 
-class _BooleanDisposable extends Object
-    with DisposableMixin
-    implements Disposable {
+class _BooleanDisposable extends Object with DisposableMixin implements Disposable {
   final DisposeFunc _disposeFunc;
 
   _BooleanDisposable(this._disposeFunc);

--- a/lib/src/disposable/disposable.dart
+++ b/lib/src/disposable/disposable.dart
@@ -10,20 +10,19 @@ abstract class Disposable {
 
   /// Creates a [Disposable] from a callback.
   factory Disposable(DisposeFunc disposeFunc) {
-    checkNotNull(disposeFunc, message: () => "disposeFunc can't be null");
+    ArgumentError.checkNotNull(disposeFunc, "disposeFunc can't be null");
     return _BooleanDisposable(disposeFunc);
   }
 
   /// Composes many [DisposeFunc] into one.
   factory Disposable.compose(Iterable<DisposeFunc> disposeFuncs) {
-    checkNotNull(disposeFuncs, message: () => "disposeFuncs can't be null");
-    return Disposable.fromDisposables(
-        disposeFuncs.map((disposeFunc) => Disposable(disposeFunc)));
+    ArgumentError.checkNotNull(disposeFuncs, "disposeFuncs can't be null");
+    return Disposable.fromDisposables(disposeFuncs.map((disposeFunc) => Disposable(disposeFunc)));
   }
 
   /// Composes many [Disposable] instances to be disposed together.
   factory Disposable.fromDisposables(Iterable<Disposable> disposables) {
-    checkNotNull(disposables, message: () => "disposables can't be null");
+    ArgumentError.checkNotNull(disposables, "disposables can't be null");
     return DisposableCollection.from(disposables, autoClear: true);
   }
 }
@@ -33,8 +32,8 @@ typedef void DisposableBlock<D extends Disposable>(D disposable);
 
 /// Use a [Disposable] and dispose of it right away.
 void using<D extends Disposable>(Disposable disposable, DisposableBlock block) {
-  checkNotNull(disposable, message: () => "disposable can't be null");
-  checkNotNull(block, message: () => "block can't be null");
+  ArgumentError.checkNotNull(disposable, "disposable can't be null");
+  ArgumentError.checkNotNull(block, "block can't be null");
   block(disposable);
   disposable.dispose();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,14 @@
 name: disposables
 description: Simple library to manage objects needing to release its own resources.
-version: 0.1.2
+version: 1.0.0
 homepage: https://github.com/marcguilera/disposables.dart
 author: marcguilera <marcguilerap@gmail.com>
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  quiver: ^2.0.1
+  quiver: ^3.0.0
 
 dev_dependencies:
-  test: ^1.0.0
+  test: ^1.16.7


### PR DESCRIPTION
Simple changes to support null safety, plus `checkNotNull()` is now deprecated.